### PR TITLE
Fix type hints in taylor_bounds to support int and float arguments.

### DIFF
--- a/autobound/jax/jax_bound.py
+++ b/autobound/jax/jax_bound.py
@@ -58,10 +58,10 @@ class TaylorBounds:
 
 
 def taylor_bounds(
-    f: Callable[[jnp.ndarray], jnp.ndarray],
+    f: Callable[[types.NDArrayLike], types.NDArrayLike],
     max_degree: int,
     propagate_trust_regions: bool = False,
-) -> Callable[[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]], TaylorBounds]:
+) -> Callable[[types.NDArrayLike, tuple[types.NDArrayLike, types.NDArrayLike]], TaylorBounds]:
   """Returns version of f that returns a TaylorBounds object.
 
   Args:


### PR DESCRIPTION
In the README example, Pyright complains about the arguments to taylor_bounds since the types of the Callable are restricted to jnp.ndarray and not types.NDArraylike which also supports int, float etc.